### PR TITLE
apitrace: Added package

### DIFF
--- a/package/Config.in
+++ b/package/Config.in
@@ -18,6 +18,7 @@ source "package/xz/Config.in"
 endmenu
 
 menu "Debugging, profiling and benchmark"
+source "package/apitrace/Config.in"
 source "package/bonnie/Config.in"
 source "package/dhrystone/Config.in"
 source "package/dstat/Config.in"

--- a/package/apitrace/Config.in
+++ b/package/apitrace/Config.in
@@ -1,0 +1,15 @@
+config BR2_PACKAGE_APITRACE
+	bool "apitrace"
+	select BR2_PACKAGE_POPT
+	select BR2_PACKAGE_BINUTILS
+	depends on BR2_INSTALL_LIBSTDCPP
+	depends on !BR2_aarch64 # binutils
+	help
+          apitrace consists of a set of tools to:
+          * trace OpenGL, OpenGL ES, Direct3D, and DirectDraw APIs calls to a file;
+          * replay OpenGL and OpenGL ES calls from a file;
+          * inspect OpenGL state at any call while retracing;
+          * visualize and edit trace files.
+
+comment "apitrace requires a toolchain with C++ support enabled"
+	depends on !BR2_INSTALL_LIBSTDCPP

--- a/package/apitrace/apitrace-0ef175f-001-fbdev.patch
+++ b/package/apitrace/apitrace-0ef175f-001-fbdev.patch
@@ -1,0 +1,459 @@
+From 317bc797bcbe2b41243876a4791e65484da0b39d Mon Sep 17 00:00:00 2001
+From: "Wladimir J. van der Laan" <laanwj@gmail.com>
+Date: Sun, 25 Aug 2013 22:04:46 +0200
+Subject: [PATCH] Use fbdev instead of X11
+
+Replay egl traces on the raw fbdev device.
+---
+ dispatch/glproc_egl.cpp              |    5 +-
+ retrace/CMakeLists.txt               |    5 +-
+ retrace/glws_egl_fbdev.cpp           |  335 ++++++++++++++++++++++++++++++++++
+ thirdparty/khronos/EGL/eglplatform.h |   35 +++-
+ 4 files changed, 366 insertions(+), 14 deletions(-)
+ create mode 100644 retrace/glws_egl_fbdev.cpp
+
+diff --git a/dispatch/glproc_egl.cpp b/dispatch/glproc_egl.cpp
+index abba727..b927b8d 100644
+--- a/dispatch/glproc_egl.cpp
++++ b/dispatch/glproc_egl.cpp
+@@ -70,7 +70,10 @@ void *_libGlHandle = NULL;
+ void *
+ _getPublicProcAddress(const char *procName)
+ {
+-#if defined(ANDROID)
++/* For some reason, the other path fails to find the function, so follow the Android
++ * path for now.
++ */
++#if 1 //defined(ANDROID)
+     /*
+      * Android does not support LD_PRELOAD.  It is assumed that applications
+      * are explicitely loading egltrace.so.
+diff --git a/retrace/CMakeLists.txt b/retrace/CMakeLists.txt
+index 78cceae..941dc34 100644
+--- a/retrace/CMakeLists.txt
++++ b/retrace/CMakeLists.txt
+@@ -113,9 +113,9 @@ if (WIN32 OR APPLE OR X11_FOUND)
+     install (TARGETS glretrace RUNTIME DESTINATION bin) 
+ endif ()
+ 
+-if (ENABLE_EGL AND X11_FOUND AND NOT WIN32 AND NOT APPLE)
++if (ENABLE_EGL AND NOT WIN32 AND NOT APPLE)
+     add_executable (eglretrace
+-        glws_egl_xlib.cpp
++        glws_egl_fbdev.cpp
+     )
+ 
+     add_dependencies (eglretrace glproc)
+@@ -124,7 +124,6 @@ if (ENABLE_EGL AND X11_FOUND AND NOT WIN32 AND NOT APPLE)
+         retrace_common
+         glretrace_common
+         glproc_egl
+-        ${X11_X11_LIB}
+         ${CMAKE_THREAD_LIBS_INIT}
+         dl
+     )
+diff --git a/retrace/glws_egl_fbdev.cpp b/retrace/glws_egl_fbdev.cpp
+new file mode 100644
+index 0000000..be116c8
+--- /dev/null
++++ b/retrace/glws_egl_fbdev.cpp
+@@ -0,0 +1,335 @@
++/**************************************************************************
++ *
++ * Copyright 2011 LunarG, Inc.
++ * Copyright 2011 Jose Fonseca
++ * Copyright 2013 Wladimir J. van der Laan
++ * All Rights Reserved.
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to deal
++ * in the Software without restriction, including without limitation the rights
++ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++ * copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in
++ * all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
++ * THE SOFTWARE.
++ *
++ **************************************************************************/
++
++#include <assert.h>
++#include <stdlib.h>
++
++#include <iostream>
++
++#include <dlfcn.h>
++
++#include "glproc.hpp"
++#include "glws.hpp"
++
++
++namespace glws {
++
++static EGLDisplay eglDisplay = EGL_NO_DISPLAY;
++
++class EglVisual : public Visual
++{
++public:
++    EGLConfig config;
++
++    EglVisual() :
++        config(0)
++    {}
++
++    ~EglVisual() {
++    }
++};
++
++class EglDrawable : public Drawable
++{
++public:
++    EGLSurface surface;
++    EGLint api;
++    EGLNativeWindowType window;
++
++    EglDrawable(const Visual *vis, int w, int h, bool pbuffer) :
++        Drawable(vis, w, h, pbuffer),
++        api(EGL_OPENGL_ES_API)
++    {
++        eglWaitNative(EGL_CORE_NATIVE_ENGINE);
++
++        window = (EGLNativeWindowType)NULL; /* No windows for fbdev */
++
++        EGLConfig config = static_cast<const EglVisual *>(visual)->config;
++        surface = eglCreateWindowSurface(eglDisplay, config, window, NULL);
++    }
++
++    ~EglDrawable() {
++        eglDestroySurface(eglDisplay, surface);
++        eglWaitClient();
++        eglWaitNative(EGL_CORE_NATIVE_ENGINE);
++    }
++
++    void
++    recreate(void) {
++        EGLContext currentContext = eglGetCurrentContext();
++        EGLSurface currentDrawSurface = eglGetCurrentSurface(EGL_DRAW);
++        EGLSurface currentReadSurface = eglGetCurrentSurface(EGL_READ);
++        bool rebindDrawSurface = currentDrawSurface == surface;
++        bool rebindReadSurface = currentReadSurface == surface;
++
++        if (rebindDrawSurface || rebindReadSurface) {
++            eglMakeCurrent(eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
++        }
++
++        eglDestroySurface(eglDisplay, surface);
++
++        EGLConfig config = static_cast<const EglVisual *>(visual)->config;
++        surface = eglCreateWindowSurface(eglDisplay, config, (EGLNativeWindowType)window, NULL);
++
++        if (rebindDrawSurface || rebindReadSurface) {
++            eglMakeCurrent(eglDisplay, surface, surface, currentContext);
++        }
++    }
++
++    void
++    resize(int w, int h) {
++        return;
++    }
++
++    void show(void) {
++        if (visible) {
++            return;
++        }
++
++        eglWaitClient();
++
++        eglWaitNative(EGL_CORE_NATIVE_ENGINE);
++
++        Drawable::show();
++    }
++
++    void swapBuffers(void) {
++        eglBindAPI(api);
++        eglSwapBuffers(eglDisplay, surface);
++    }
++};
++
++
++class EglContext : public Context
++{
++public:
++    EGLContext context;
++
++    EglContext(const Visual *vis, Profile prof, EGLContext ctx) :
++        Context(vis, prof),
++        context(ctx)
++    {}
++
++    ~EglContext() {
++        eglDestroyContext(eglDisplay, context);
++    }
++};
++
++/**
++ * Load the symbols from the specified shared object into global namespace, so
++ * that they can be later found by dlsym(RTLD_NEXT, ...);
++ */
++static void
++load(const char *filename)
++{
++    if (!dlopen(filename, RTLD_GLOBAL | RTLD_LAZY)) {
++        std::cerr << "error: unable to open " << filename << "\n";
++        exit(1);
++    }
++}
++
++void
++init(void) {
++    load("libEGL.so.1");
++
++    eglDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
++    if (eglDisplay == EGL_NO_DISPLAY) {
++        std::cerr << "error: unable to get EGL display\n";
++        exit(1);
++    }
++
++    EGLint major, minor;
++    if (!eglInitialize(eglDisplay, &major, &minor)) {
++        std::cerr << "error: unable to initialize EGL display\n";
++        exit(1);
++    }
++}
++
++void
++cleanup(void) {
++    if (eglDisplay) {
++        eglTerminate(eglDisplay);
++        eglDisplay = NULL;
++    }
++}
++
++Visual *
++createVisual(bool doubleBuffer, Profile profile) {
++    EglVisual *visual = new EglVisual();
++    // possible combinations
++    const EGLint api_bits_gl[7] = {
++        EGL_OPENGL_BIT | EGL_OPENGL_ES_BIT | EGL_OPENGL_ES2_BIT,
++        EGL_OPENGL_BIT | EGL_OPENGL_ES_BIT,
++        EGL_OPENGL_BIT | EGL_OPENGL_ES2_BIT,
++        EGL_OPENGL_BIT,
++        EGL_OPENGL_ES_BIT | EGL_OPENGL_ES2_BIT,
++        EGL_OPENGL_ES2_BIT,
++        EGL_OPENGL_ES_BIT,
++    };
++    const EGLint api_bits_gles1[7] = {
++        EGL_OPENGL_BIT | EGL_OPENGL_ES_BIT | EGL_OPENGL_ES2_BIT,
++        EGL_OPENGL_ES_BIT | EGL_OPENGL_ES2_BIT,
++        EGL_OPENGL_BIT | EGL_OPENGL_ES_BIT,
++        EGL_OPENGL_ES_BIT,
++        EGL_OPENGL_BIT | EGL_OPENGL_ES2_BIT,
++        EGL_OPENGL_BIT,
++        EGL_OPENGL_ES2_BIT,
++    };
++    const EGLint api_bits_gles2[7] = {
++        EGL_OPENGL_BIT | EGL_OPENGL_ES_BIT | EGL_OPENGL_ES2_BIT,
++        EGL_OPENGL_ES_BIT | EGL_OPENGL_ES2_BIT,
++        EGL_OPENGL_BIT | EGL_OPENGL_ES2_BIT,
++        EGL_OPENGL_ES2_BIT,
++        EGL_OPENGL_BIT | EGL_OPENGL_ES_BIT,
++        EGL_OPENGL_BIT,
++        EGL_OPENGL_ES_BIT,
++    };
++    const EGLint *api_bits;
++
++    switch(profile) {
++    case PROFILE_COMPAT:
++        api_bits = api_bits_gl;
++        break;
++    case PROFILE_ES1:
++        api_bits = api_bits_gles1;
++        break;
++    case PROFILE_ES2:
++        api_bits = api_bits_gles2;
++        break;
++    default:
++        return NULL;
++    };
++
++    for (int i = 0; i < 7; i++) {
++        Attributes<EGLint> attribs;
++
++        attribs.add(EGL_SURFACE_TYPE, EGL_WINDOW_BIT);
++        attribs.add(EGL_RED_SIZE, 1);
++        attribs.add(EGL_GREEN_SIZE, 1);
++        attribs.add(EGL_BLUE_SIZE, 1);
++        attribs.add(EGL_ALPHA_SIZE, 1);
++        attribs.add(EGL_DEPTH_SIZE, 1);
++        attribs.add(EGL_STENCIL_SIZE, 1);
++        attribs.add(EGL_RENDERABLE_TYPE, api_bits[i]);
++        attribs.end(EGL_NONE);
++
++        EGLint num_configs, vid;
++        if (eglChooseConfig(eglDisplay, attribs, &visual->config, 1, &num_configs) &&
++            num_configs == 1 &&
++            eglGetConfigAttrib(eglDisplay, visual->config, EGL_NATIVE_VISUAL_ID, &vid)) {
++            break;
++        }
++    }
++
++    return visual;
++}
++
++Drawable *
++createDrawable(const Visual *visual, int width, int height, bool pbuffer)
++{
++    return new EglDrawable(visual, width, height, pbuffer);
++}
++
++Context *
++createContext(const Visual *_visual, Context *shareContext, Profile profile, bool debug)
++{
++    const EglVisual *visual = static_cast<const EglVisual *>(_visual);
++    EGLContext share_context = EGL_NO_CONTEXT;
++    EGLContext context;
++    Attributes<EGLint> attribs;
++
++    if (shareContext) {
++        share_context = static_cast<EglContext*>(shareContext)->context;
++    }
++
++    EGLint api = eglQueryAPI();
++
++    switch (profile) {
++    case PROFILE_COMPAT:
++        load("libGL.so.1");
++        eglBindAPI(EGL_OPENGL_API);
++        break;
++    case PROFILE_CORE:
++        assert(0);
++        return NULL;
++    case PROFILE_ES1:
++        load("libGLESv1_CM.so.1");
++        eglBindAPI(EGL_OPENGL_ES_API);
++        break;
++    case PROFILE_ES2:
++        load("libGLESv2.so.2");
++        eglBindAPI(EGL_OPENGL_ES_API);
++        attribs.add(EGL_CONTEXT_CLIENT_VERSION, 2);
++        break;
++    default:
++        return NULL;
++    }
++
++    attribs.end(EGL_NONE);
++
++    context = eglCreateContext(eglDisplay, visual->config, share_context, attribs);
++    if (!context)
++        return NULL;
++
++    eglBindAPI(api);
++
++    return new EglContext(visual, profile, context);
++}
++
++bool
++makeCurrent(Drawable *drawable, Context *context)
++{
++    if (!drawable || !context) {
++        return eglMakeCurrent(eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
++    } else {
++        EglDrawable *eglDrawable = static_cast<EglDrawable *>(drawable);
++        EglContext *eglContext = static_cast<EglContext *>(context);
++        EGLBoolean ok;
++
++        ok = eglMakeCurrent(eglDisplay, eglDrawable->surface,
++                            eglDrawable->surface, eglContext->context);
++
++        if (ok) {
++            EGLint api;
++
++            eglQueryContext(eglDisplay, eglContext->context,
++                            EGL_CONTEXT_CLIENT_TYPE, &api);
++
++            eglDrawable->api = api;
++        }
++
++        return ok;
++    }
++}
++
++bool
++processEvents(void) {
++    return true;
++}
++
++
++} /* namespace glws */
+diff --git a/thirdparty/khronos/EGL/eglplatform.h b/thirdparty/khronos/EGL/eglplatform.h
+index b5995ec..21b18fe 100644
+--- a/thirdparty/khronos/EGL/eglplatform.h
++++ b/thirdparty/khronos/EGL/eglplatform.h
+@@ -83,24 +83,37 @@ typedef int   EGLNativeDisplayType;
+ typedef void *EGLNativeWindowType;
+ typedef void *EGLNativePixmapType;
+ 
+-#elif defined(__ANDROID__) || defined(ANDROID)
++#elif defined(WL_EGL_PLATFORM)
+ 
+-#include <android/native_window.h>
++typedef struct wl_display     *EGLNativeDisplayType;
++typedef struct wl_egl_pixmap  *EGLNativePixmapType;
++typedef struct wl_egl_window  *EGLNativeWindowType;
+ 
+-struct egl_native_pixmap_t;
++#elif defined(__GBM__)
+ 
+-typedef struct ANativeWindow*           EGLNativeWindowType;
+-typedef struct egl_native_pixmap_t*     EGLNativePixmapType;
+-typedef void*                           EGLNativeDisplayType;
++typedef struct gbm_device  *EGLNativeDisplayType;
++typedef struct gbm_bo      *EGLNativePixmapType;
++typedef void               *EGLNativeWindowType;
+ 
+-#elif defined(__APPLE__)
++#elif defined(ANDROID) /* Android */
+ 
+-typedef void *EGLNativeDisplayType;
+-typedef void *EGLNativePixmapType;
+-typedef void *EGLNativeWindowType;
++struct ANativeWindow;
++struct egl_native_pixmap_t;
++
++typedef struct ANativeWindow        *EGLNativeWindowType;
++typedef struct egl_native_pixmap_t  *EGLNativePixmapType;
++typedef void                        *EGLNativeDisplayType;
+ 
+ #elif defined(__unix__)
+ 
++#ifdef MESA_EGL_NO_X11_HEADERS
++
++typedef void            *EGLNativeDisplayType;
++typedef khronos_uintptr_t EGLNativePixmapType;
++typedef khronos_uintptr_t EGLNativeWindowType;
++
++#else
++
+ /* X11 (tentative)  */
+ #include <X11/Xlib.h>
+ #include <X11/Xutil.h>
+@@ -109,6 +122,8 @@ typedef Display *EGLNativeDisplayType;
+ typedef Pixmap   EGLNativePixmapType;
+ typedef Window   EGLNativeWindowType;
+ 
++#endif /* MESA_EGL_NO_X11_HEADERS */
++
+ #else
+ #error "Platform not recognized"
+ #endif
+-- 
+1.7.9.5
+

--- a/package/apitrace/apitrace.mk
+++ b/package/apitrace/apitrace.mk
@@ -1,0 +1,18 @@
+#############################################################
+#
+# apitrace
+#
+#############################################################
+
+APITRACE_VERSION = 0ef175f
+APITRACE_SITE = git://github.com/apitrace/apitrace.git
+
+APITRACE_CONF_OPT =
+ifneq ($(BR2_PACKAGE_XLIB_LIBX11),y)
+APITRACE_CONF_OPT += -DCMAKE_C_FLAGS:STRING="$(TARGET_CFLAGS) -DMESA_EGL_NO_X11_HEADERS"
+APITRACE_CONF_OPT += -DCMAKE_CXX_FLAGS:STRING="$(TARGET_CFLAGS) -DMESA_EGL_NO_X11_HEADERS"
+endif
+
+APITRACE_DEPENDENCIES = popt binutils
+
+$(eval $(cmake-package))


### PR DESCRIPTION
Add `apitrace` and `eglretrace`, for GLES debugging and profiling.

_Usage for tracing:_

```
apitrace trace -a egl ./glquake
```

This will create a file glquake.trace in the current directory (by default).

_Usage for replaying:_

```
eglretrace glquake.trace
```

There is also functionality for cutting/manipulating traces, for example to isolate certain frames, see `apitrace trim --help`.
It should also be possible to copy the resulting trace files to a desktop for examination using the qapitrace GUI (not yet tried).
