### PR TITLE
uClibc: Fix dlsym RTLD_NEXT

### DIFF
--- a/package/apitrace/apitrace-0ef175f-001-fbdev.patch
+++ b/package/apitrace/apitrace-0ef175f-001-fbdev.patch
@@ -1,33 +1,16 @@
-From 317bc797bcbe2b41243876a4791e65484da0b39d Mon Sep 17 00:00:00 2001
+From ce9b10b47ebfb69aac9a2367363ca8ddda32cf7f Mon Sep 17 00:00:00 2001
 From: "Wladimir J. van der Laan" <laanwj@gmail.com>
 Date: Sun, 25 Aug 2013 22:04:46 +0200
 Subject: [PATCH] Use fbdev instead of X11
 
 Replay egl traces on the raw fbdev device.
 ---
- dispatch/glproc_egl.cpp              |    5 +-
  retrace/CMakeLists.txt               |    5 +-
  retrace/glws_egl_fbdev.cpp           |  335 ++++++++++++++++++++++++++++++++++
  thirdparty/khronos/EGL/eglplatform.h |   35 +++-
- 4 files changed, 366 insertions(+), 14 deletions(-)
+ 3 files changed, 362 insertions(+), 13 deletions(-)
  create mode 100644 retrace/glws_egl_fbdev.cpp
 
-diff --git a/dispatch/glproc_egl.cpp b/dispatch/glproc_egl.cpp
-index abba727..b927b8d 100644
---- a/dispatch/glproc_egl.cpp
-+++ b/dispatch/glproc_egl.cpp
-@@ -70,7 +70,10 @@ void *_libGlHandle = NULL;
- void *
- _getPublicProcAddress(const char *procName)
- {
--#if defined(ANDROID)
-+/* For some reason, the other path fails to find the function, so follow the Android
-+ * path for now.
-+ */
-+#if 1 //defined(ANDROID)
-     /*
-      * Android does not support LD_PRELOAD.  It is assumed that applications
-      * are explicitely loading egltrace.so.
 diff --git a/retrace/CMakeLists.txt b/retrace/CMakeLists.txt
 index 78cceae..941dc34 100644
 --- a/retrace/CMakeLists.txt

--- a/toolchain/uClibc/uClibc-0.9.33.2-rtld_next-fix.patch
+++ b/toolchain/uClibc/uClibc-0.9.33.2-rtld_next-fix.patch
@@ -1,0 +1,37 @@
+Signed-off-by: Timo Teräs <timo.teras at iki.fi
+Reviewed-by: Filippo ARCIDIACONO <filippo.arcidiacono at st.com>
+Tested-by: Florian Fainelli <florian at openwrt.org>
+---
+ ldso/libdl/libdl.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/ldso/libdl/libdl.c b/ldso/libdl/libdl.c
+index af632dd..95a0650 100644
+--- a/ldso/libdl/libdl.c
++++ b/ldso/libdl/libdl.c
+@@ -671,7 +671,7 @@ static void *do_dlsym(void *vhandle, const char *name, void *caller_address)
+ {
+ 	struct elf_resolve *tpnt, *tfrom;
+ 	struct dyn_elf *handle;
+-	ElfW(Addr) from;
++	ElfW(Addr) from = 0;
+ 	struct dyn_elf *rpnt;
+ 	void *ret;
+ 	struct symbol_ref sym_ref = { NULL, NULL };
+@@ -729,7 +729,13 @@ static void *do_dlsym(void *vhandle, const char *name, void *caller_address)
+ 	tpnt = NULL;
+ 	if (handle == _dl_symbol_tables)
+ 		tpnt = handle->dyn; /* Only search RTLD_GLOBAL objs if global object */
+-	ret = _dl_find_hash(name2, &handle->dyn->symbol_scope, tpnt, ELF_RTYPE_CLASS_DLSYM, &sym_ref);
++
++	do {
++		ret = _dl_find_hash(name2, &handle->dyn->symbol_scope, tpnt, ELF_RTYPE_CLASS_DLSYM, &sym_ref);
++		if (ret != NULL)
++			break;
++		handle = handle->next;
++	} while (from && handle);
+ 
+ #if defined(USE_TLS) && USE_TLS && defined SHARED
+ 	if (sym_ref.sym && (ELF_ST_TYPE(sym_ref.sym->st_info) == STT_TLS) && (sym_ref.tpnt)) {
+-- 
+1.8.1


### PR DESCRIPTION
This is necessary for apitrace to work properly with games (such as
d2x-rebirth) that load the EGL library with dlopen. Without this change there
is no way to interpose `dlopen`.

With this change the apitrace patch can be simplified, as no longer the ANDROID
path needs to be forced to locate EGL/GLES symbols.

The patch comes from
http://lists.uclibc.org/pipermail/uclibc/2013-January/047373.html and
has already been merged upstream. It is thus to be expected it will no
longer be needed for a next uClibc version.
