### PR TITLE
mesa3d-etna_viv: no longer need MESA_EGL_NO_X11_HEADERS

### DIFF
--- a/package/mesa3d-etna_viv/mesa3d-etna_viv-0ef175f-001-include-EGL-always-imply-MESA_EGL_NO_X11_HEADERS.patch
+++ b/package/mesa3d-etna_viv/mesa3d-etna_viv-0ef175f-001-include-EGL-always-imply-MESA_EGL_NO_X11_HEADERS.patch
@@ -1,0 +1,44 @@
+From d987b0dfd3c901336547887105d0bc14b6458a73 Mon Sep 17 00:00:00 2001
+From: "Wladimir J. van der Laan" <laanwj@gmail.com>
+Date: Sun, 15 Sep 2013 18:52:38 +0200
+Subject: [PATCH] include: EGL: always imply MESA_EGL_NO_X11_HEADERS
+
+As we don't use X11 on GCW Zero, this avoids people having to
+define MESA_EGL_NO_X11_HEADERS when compiling games.
+---
+ include/EGL/eglplatform.h |   14 --------------
+ 1 file changed, 14 deletions(-)
+
+diff --git a/include/EGL/eglplatform.h b/include/EGL/eglplatform.h
+index 21b18fe..c8ccb85 100644
+--- a/include/EGL/eglplatform.h
++++ b/include/EGL/eglplatform.h
+@@ -106,25 +106,11 @@ typedef void                        *EGLNativeDisplayType;
+ 
+ #elif defined(__unix__)
+ 
+-#ifdef MESA_EGL_NO_X11_HEADERS
+-
+ typedef void            *EGLNativeDisplayType;
+ typedef khronos_uintptr_t EGLNativePixmapType;
+ typedef khronos_uintptr_t EGLNativeWindowType;
+ 
+ #else
+-
+-/* X11 (tentative)  */
+-#include <X11/Xlib.h>
+-#include <X11/Xutil.h>
+-
+-typedef Display *EGLNativeDisplayType;
+-typedef Pixmap   EGLNativePixmapType;
+-typedef Window   EGLNativeWindowType;
+-
+-#endif /* MESA_EGL_NO_X11_HEADERS */
+-
+-#else
+ #error "Platform not recognized"
+ #endif
+ 
+-- 
+1.7.9.5
+

--- a/package/mesa3d-etna_viv/mesa3d-etna_viv.mk
+++ b/package/mesa3d-etna_viv/mesa3d-etna_viv.mk
@@ -17,10 +17,6 @@ MESA3D_ETNA_VIV_CONF_ENV = \
 	PYTHON2="$(HOST_DIR)/usr/bin/python2" \
 	ETNA_LIBS="$(STAGING_DIR)/usr/lib/libetnaviv.a"
 
-ifneq ($(BR2_PACKAGE_XLIB_LIBX11),y)
-MESA3D_ETNA_VIV_CONF_ENV += CFLAGS="$(TARGET_CFLAGS) -DMESA_EGL_NO_X11_HEADERS"
-endif
-
 MESA3D_ETNA_VIV_CONF_OPT = \
 	--enable-gles1 \
 	--enable-gles2 \


### PR DESCRIPTION
As discussed on IRC today.
Override eglplatform.h so that defining MESA_EGL_NO_X11_HEADERS no longer needs to be defined when compiling mesa itself or software using it.
