### PR TITLE
toolchain: gcc: support -mmxu

### DIFF
--- a/toolchain/gcc/4.6.3/999-mxu.patch
+++ b/toolchain/gcc/4.6.3/999-mxu.patch
@@ -1,0 +1,38 @@
+From 793e263d62bb7f85426899cd7a86e821dd38d12a Mon Sep 17 00:00:00 2001
+From: Andrew Hsieh <andrewhsieh@google.com>
+Date: Thu, 15 Aug 2013 11:36:10 +0800
+Subject: [PATCH] Add MXU support in gcc4.6/4.7/4.8 with -mmxu
+
+For Ingenic MXU.
+
+Change-Id: Ie7b465c971e3642b3244ac1a77b6f86be4ab4fea
+
+diff --git a/gcc/config/mips/mips.h b/gcc-4.6/gcc/config/mips/mips.h
+index 79b806d..6647899 100644
+--- a/gcc/config/mips/mips.h
++++ b/gcc/config/mips/mips.h
+@@ -1130,6 +1130,7 @@ enum mips_code_readable_setting {
+ %{mdspr2} %{mno-dspr2} \
+ %{msmartmips} %{mno-smartmips} \
+ %{mmt} %{mno-mt} \
++%{mmxu} %{mno-mxu} \
+ %{mfix-vr4120} %{mfix-vr4130} \
+ %(subtarget_asm_optimizing_spec) \
+ %(subtarget_asm_debugging_spec) \
+diff --git a/gcc/config/mips/mips.opt b/gcc-4.6/gcc/config/mips/mips.opt
+index 4be40b1..cb4bbbe 100644
+--- a/gcc/config/mips/mips.opt
++++ b/gcc/config/mips/mips.opt
+@@ -234,6 +234,10 @@ mmt
+ Target Report Var(TARGET_MT)
+ Allow the use of MT instructions
+
++mmxu
++Target Report Var(TARGET_MXU)
++Allow the use of MXU instructions
++
+ mno-float
+ Target Report RejectNegative Var(TARGET_NO_FLOAT) Condition(TARGET_SUPPORTS_NO_FLOAT)
+ Prevent the use of all floating-point operations
+--
+1.7.9.5

--- a/toolchain/gcc/4.7.3/999-mxu.patch
+++ b/toolchain/gcc/4.7.3/999-mxu.patch
@@ -1,0 +1,38 @@
+From 793e263d62bb7f85426899cd7a86e821dd38d12a Mon Sep 17 00:00:00 2001
+From: Andrew Hsieh <andrewhsieh@google.com>
+Date: Thu, 15 Aug 2013 11:36:10 +0800
+Subject: [PATCH] Add MXU support in gcc4.6/4.7/4.8 with -mmxu
+
+For Ingenic MXU.
+
+Change-Id: Ie7b465c971e3642b3244ac1a77b6f86be4ab4fea
+
+diff --git a/gcc/config/mips/mips.h b/gcc-4.7/gcc/config/mips/mips.h
+index 5146cc5..71c55d2 100644
+--- a/gcc/config/mips/mips.h
++++ b/gcc/config/mips/mips.h
+@@ -1129,6 +1129,7 @@ struct mips_cpu_info {
+ %{mdspr2} %{mno-dspr2} \
+ %{msmartmips} %{mno-smartmips} \
+ %{mmt} %{mno-mt} \
++%{mmxu} %{mno-mxu} \
+ %{mfix-vr4120} %{mfix-vr4130} \
+ %{mfix-24k} \
+ %{noasmopt:-O0; O0|fno-delayed-branch:-O1; O*:-O2; :-O1} \
+diff --git a/gcc/config/mips/mips.opt b/gcc-4.7/gcc/config/mips/mips.opt
+index 8dba482..8f01998 100644
+--- a/gcc/config/mips/mips.opt
++++ b/gcc/config/mips/mips.opt
+@@ -269,6 +269,10 @@ mmt
+ Target Report Var(TARGET_MT)
+ Allow the use of MT instructions
+
++mmxu
++Target Report Var(TARGET_MXU)
++Allow the use of MXU instructions
++
+ mno-float
+ Target Report RejectNegative Var(TARGET_NO_FLOAT) Condition(TARGET_SUPPORTS_NO_FLOAT)
+ Prevent the use of all floating-point operations
+--
+1.7.9.5

--- a/toolchain/gcc/4.8.1/999-mxu.patch
+++ b/toolchain/gcc/4.8.1/999-mxu.patch
@@ -1,0 +1,38 @@
+From 793e263d62bb7f85426899cd7a86e821dd38d12a Mon Sep 17 00:00:00 2001
+From: Andrew Hsieh <andrewhsieh@google.com>
+Date: Thu, 15 Aug 2013 11:36:10 +0800
+Subject: [PATCH] Add MXU support in gcc4.6/4.7/4.8 with -mmxu
+
+For Ingenic MXU.
+
+Change-Id: Ie7b465c971e3642b3244ac1a77b6f86be4ab4fea
+
+diff --git a/gcc/config/mips/mips.h b/gcc-4.8/gcc/config/mips/mips.h
+index 1ad8d7d..819571c 100644
+--- a/gcc/config/mips/mips.h
++++ b/gcc/config/mips/mips.h
+@@ -1127,6 +1127,7 @@ struct mips_cpu_info {
+ %{mmcu} %{mno-mcu} \
+ %{msmartmips} %{mno-smartmips} \
+ %{mmt} %{mno-mt} \
++%{mmxu} %{mno-mxu} \
+ %{mfix-vr4120} %{mfix-vr4130} \
+ %{mfix-24k} \
+ %{noasmopt:-O0; O0|fno-delayed-branch:-O1; O*:-O2; :-O1} \
+diff --git a/gcc/config/mips/mips.opt b/gcc-4.8/gcc/config/mips/mips.opt
+index b9655a5..68faba3 100644
+--- a/gcc/config/mips/mips.opt
++++ b/gcc/config/mips/mips.opt
+@@ -269,6 +269,10 @@ mmt
+ Target Report Var(TARGET_MT)
+ Allow the use of MT instructions
+
++mmxu
++Target Report Var(TARGET_MXU)
++Allow the use of MXU instructions
++
+ mno-float
+ Target Report RejectNegative Var(TARGET_NO_FLOAT) Condition(TARGET_SUPPORTS_NO_FLOAT)
+ Prevent the use of all floating-point operations
+--
+1.7.9.5


### PR DESCRIPTION
This patch (ported from android, https://android-review.googlesource.com/#/c/63702/) allows enabling support for MXU instructions on the GCC command line with -mmxu.
This does not change anything in GCC code generation at the moment but the flag is passed through to binutils, so that the instructions can be used inline.
