### PR TITLE
Opendingux 2014.08 fixes2

### DIFF
--- a/package/libopk/libopk.mk
+++ b/package/libopk/libopk.mk
@@ -13,10 +13,10 @@ LIBOPK_MAKE_ENV = CFLAGS="$(TARGET_CFLAGS)" LDFLAGS="$(TARGET_LDFLAGS)" \
 				  CROSS_COMPILE="$(TARGET_CROSS)" PREFIX=/usr
 
 define LIBOPK_BUILD_PYTHON
-	(cd $(@D)/python ; $(HOST_DIR)/usr/bin/python setup.py build)
+	(cd $(@D)/bindings/python ; $(HOST_DIR)/usr/bin/python setup.py build)
 endef
 define LIBOPK_INSTALL_PYTHON
-	(cd $(@D)/python ; $(HOST_DIR)/usr/bin/python setup.py install --prefix=$(TARGET_DIR)/usr)
+	(cd $(@D)/bindings/python ; $(HOST_DIR)/usr/bin/python setup.py install --prefix=$(TARGET_DIR)/usr)
 endef
 
 ifeq ($(BR2_PACKAGE_PYTHON),y)

--- a/package/libpng/libpng.mk
+++ b/package/libpng/libpng.mk
@@ -7,7 +7,7 @@
 LIBPNG_VERSION = 1.4.13
 LIBPNG_SERIES = 14
 LIBPNG_SOURCE = libpng-$(LIBPNG_VERSION).tar.bz2
-LIBPNG_SITE = http://downloads.sourceforge.net/project/libpng/libpng${LIBPNG_SERIES}/$(LIBPNG_VERSION)
+LIBPNG_SITE = http://downloads.sourceforge.net/project/libpng/libpng${LIBPNG_SERIES}/older-releases/$(LIBPNG_VERSION)
 LIBPNG_LICENSE = libpng license
 LIBPNG_LICENSE_FILES = LICENSE
 LIBPNG_INSTALL_STAGING = YES


### PR DESCRIPTION
libopk: fix path to python/setup.py
libpng: fix download url, version 1.4.13 was moved to 'older-releases' subdir
