### PR TITLE
libmikmod: Fixup prefix= and exec_prefix= in libmikmod-config

### DIFF
--- a/package/libmikmod/libmikmod.mk
+++ b/package/libmikmod/libmikmod.mk
@@ -12,9 +12,19 @@ LIBMIKMOD_CONF_OPT = --localstatedir=/var \
 LIBMIKMOD_LIBTOOL_PATCH = NO
 LIBMIKMOD_INSTALL_STAGING = YES
 
+# Fixup prefix= and exec_prefix= in libmikmod-config
+define LIBMIKMOD_FIXUP_LIBMIKMOD_CONFIG
+	$(SED) 's%prefix=/usr%prefix=$(STAGING_DIR)/usr%' \
+		$(STAGING_DIR)/usr/bin/libmikmod-config
+	$(SED) 's%exec_prefix=/usr%exec_prefix=$(STAGING_DIR)/usr%' \
+		$(STAGING_DIR)/usr/bin/libmikmod-config
+endef
+
 define LIBMIKMOD_REMOVE_LIBMIKMOD_CONFIG
 rm -f $(TARGET_DIR)/usr/bin/libmikmod-config
 endef
+
+LIBMIKMOD_POST_INSTALL_STAGING_HOOKS+=LIBMIKMOD_FIXUP_LIBMIKMOD_CONFIG
 LIBMIKMOD_POST_INSTALL_TARGET_HOOKS += LIBMIKMOD_REMOVE_LIBMIKMOD_CONFIG
 
 $(eval $(autotools-package))


### PR DESCRIPTION
libmikmod-config is used in some ./configure scripts (e.g. Heroes), the prefix wasn't fixed up until now
